### PR TITLE
Feat/add git hooks

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# set this to your active development branch
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+
+# regex to validate branch name
+branch_regex='^(fix|feat|chore|ci)\/.*'
+error_msg="Aborting commit. Your branch name: '$current_branch' doesn't fit the contributing-guidelines. See: https://gist.github.com/buddiman/628d55d0b08ff0672af5f4c156afeb08"
+
+if ! grep -iqE "$branch_regex" <<< "$current_branch"; then
+  echo "$error_msg" >&2
+  exit 1
+fi
+
+# regex to validate in commit msg
+commit_regex='^(fix|feat|chore|refactor|ci|docs|test):.*'
+error_msg="Aborting commit. Your commit message: '$1' doens't fit the contributing-guidelines. See: https://gist.github.com/buddiman/628d55d0b08ff0672af5f4c156afeb08"
+
+if ! grep -iqE "$commit_regex" "$1"; then
+  echo "$error_msg" >&2
+  exit 1
+fi

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,13 +1,22 @@
 #!/usr/bin/env bash
 
 set -e # exit immediately after error
-
+echo "commit-message"
 # check if aspell is available for spell checking
-aspellInstalled=$([ "$(command -v aspell)" != "" ])
+if aspellInstalled=$([ "$(command -v aspell)" != "" ]); then
+  if aspellInstalled=$(echo "is english installed?" | aspell list --lang en); then
+    echo "Aspell is available for spell checking"
+  else
+    echo "Aspell is not available but english language is not installed"
+  fi
+else
+  echo "Aspell is not available for spell checking"
+fi
 
 # set this to your active development branch
 current_branch="$(git rev-parse --abbrev-ref HEAD)"
 
+echo "checking branch name..."
 # regex to validate branch name
 branch_regex='^(fix|feat|chore|ci)\/.*'
 error_msg="Aborting commit. Your branch name: '$current_branch' doesn't fit the contributing-guidelines. See: https://gist.github.com/buddiman/628d55d0b08ff0672af5f4c156afeb08"
@@ -22,10 +31,11 @@ if ! grep -iqE "$branch_regex" <<< "$current_branch"; then
   exit 1
 fi
 
+echo "checking commit message..."
 # regex to validate commit msg
 commit_regex='^(fix|feat|chore|refactor|ci|docs|test):.*'
 commit_message=$(cat "$1")
-error_msg="Aborting commit. Your commit message: '$commit_message' doens't fit the contributing-guidelines. See: https://gist.github.com/buddiman/628d55d0b08ff0672af5f4c156afeb08"
+error_msg="Aborting commit. Your commit message: '$commit_message' doesn't fit the contributing-guidelines. See: https://gist.github.com/buddiman/628d55d0b08ff0672af5f4c156afeb08"
 
 if $aspellInstalled && [ "$(echo "$commit_message" | aspell list --lang en)" ]; then
   echo "please check spelling for commit message: $commit_message" >&2

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+
+set -e # exit immediately after error
+
+# check if aspell is available for spell checking
+aspellInstalled=$([ "$(command -v aspell)" != "" ])
+
 # set this to your active development branch
 current_branch="$(git rev-parse --abbrev-ref HEAD)"
 
@@ -6,14 +12,25 @@ current_branch="$(git rev-parse --abbrev-ref HEAD)"
 branch_regex='^(fix|feat|chore|ci)\/.*'
 error_msg="Aborting commit. Your branch name: '$current_branch' doesn't fit the contributing-guidelines. See: https://gist.github.com/buddiman/628d55d0b08ff0672af5f4c156afeb08"
 
+if $aspellInstalled && [ "$(echo "$current_branch" | aspell list --lang en)" ]; then
+  echo "please check spelling for branch: $current_branch" >&2
+  exit 1
+fi
+
 if ! grep -iqE "$branch_regex" <<< "$current_branch"; then
   echo "$error_msg" >&2
   exit 1
 fi
 
-# regex to validate in commit msg
+# regex to validate commit msg
 commit_regex='^(fix|feat|chore|refactor|ci|docs|test):.*'
-error_msg="Aborting commit. Your commit message: '$1' doens't fit the contributing-guidelines. See: https://gist.github.com/buddiman/628d55d0b08ff0672af5f4c156afeb08"
+commit_message=$(cat "$1")
+error_msg="Aborting commit. Your commit message: '$commit_message' doens't fit the contributing-guidelines. See: https://gist.github.com/buddiman/628d55d0b08ff0672af5f4c156afeb08"
+
+if $aspellInstalled && [ "$(echo "$commit_message" | aspell list --lang en)" ]; then
+  echo "please check spelling for commit message: $commit_message" >&2
+  exit 1
+fi
 
 if ! grep -iqE "$commit_regex" "$1"; then
   echo "$error_msg" >&2

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npm install

--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,4 +1,6 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+set -e # exit immediately after error
+
 npm install

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+set -e # exit immediately after error
+
 #npm test -- --watchAll=false # <-- do testing in CI phase
 npm run lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+#npm test -- --watchAll=false # <-- do testing in CI phase
+npm run lint

--- a/README.md
+++ b/README.md
@@ -1,3 +1,46 @@
 # MuesliNext
 
-MÜSLI replacement with intutable
+MÜSLI replacement with intutable as backend and react framework for frontend
+
+## Installation
+
+clone this repository
+
+```bash
+git clone git@github.com:pvs-hd-tea/MuesliNext.git
+```
+
+or via https
+
+```bash
+git clone https://github.com/pvs-hd-tea/MuesliNext.git
+```
+
+install dependencies
+
+```bash
+npm install
+```
+
+start the app
+
+```bash
+npm start
+```
+
+## Contributing
+
+For contributions please follow the [contribution guideline](https://gist.github.com/buddiman/628d55d0b08ff0672af5f4c156afeb08)
+
+Additionally you can only commit if the code following certain quality criteria.
+E.g. is linted and formated correctly. To format the code automatically if possible run:
+
+```bash
+npm run format
+```
+
+You should never but could always bypass these rules with:
+
+```bash
+git commit --no-verify
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint": "^8.17.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-react": "^7.30.0",
+        "husky": "^8.0.0",
         "prettier": "2.6.2"
       }
     },
@@ -8709,6 +8710,21 @@
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "dev": true,
+      "bin": {
+        "husky": "lib/bin.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {
@@ -22824,6 +22840,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw=="
+    },
+    "husky": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.1.tgz",
+      "integrity": "sha512-xs7/chUH/CKdOCs7Zy0Aev9e/dKOMZf3K1Az1nar3tzlv0jfqnYtu235bstsWTmXOR0EfINrPa97yy4Lz6RiKw==",
+      "dev": true
     },
     "iconv-lite": {
       "version": "0.6.3",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint src && prettier --check .",
-    "format": "eslint src --fix && prettier --write ."
+    "format": "eslint src --fix && prettier --write .",
+    "prepare": "husky install"
   },
   "eslintConfig": {
     "extends": [
@@ -48,6 +49,7 @@
     "eslint": "^8.17.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-react": "^7.30.0",
-    "prettier": "2.6.2"
+    "prettier": "2.6.2",
+    "husky": "^8.0.0"
   }
 }


### PR DESCRIPTION
Added git hooks:

- pre-commit: ensures only linted and formatted code can be commited
- commit-msg: ensures commit-msg and branch-name match the contribution guidelines (also checks for typos if "aspell" is installed)
- post-checkout: run npm install after checkout branch

The pre-commit hook will not check test or build success. This will be done by CI

closes #32 