### PR TITLE
Feat/inline dynamic value

### DIFF
--- a/src/components/Widgets/CustomParagraph.css
+++ b/src/components/Widgets/CustomParagraph.css
@@ -1,0 +1,35 @@
+.ce-paragraph {
+  line-height: 1.6em;
+  outline: none;
+}
+
+.ce-paragraph[data-placeholder]:empty::before {
+  content: attr(data-placeholder);
+  color: #707684;
+  font-weight: normal;
+  opacity: 0;
+}
+
+/** Show placeholder at the first paragraph if Editor is empty */
+.codex-editor--empty
+  .ce-block:first-child
+  .ce-paragraph[data-placeholder]:empty::before {
+  opacity: 1;
+}
+
+.codex-editor--toolbox-opened
+  .ce-block:first-child
+  .ce-paragraph[data-placeholder]:empty::before,
+.codex-editor--empty
+  .ce-block:first-child
+  .ce-paragraph[data-placeholder]:empty:focus::before {
+  opacity: 0;
+}
+
+.ce-paragraph p:first-of-type {
+  margin-top: 0;
+}
+
+.ce-paragraph p:last-of-type {
+  margin-bottom: 0;
+}

--- a/src/components/Widgets/CustomParagraph.tsx
+++ b/src/components/Widgets/CustomParagraph.tsx
@@ -1,0 +1,327 @@
+import { API, HTMLPasteEvent } from "@editorjs/editorjs";
+import "./CustomParagraph.css";
+
+/**
+ * Base Paragraph Block for the Editor.js.
+ * Represents simple paragraph
+ *
+ * @author CodeX (team@codex.so)
+ * @copyright CodeX 2018
+ * @license The MIT License (MIT)
+ */
+
+/**
+ * @typedef {object} ParagraphConfig
+ * @property {string} placeholder - placeholder for the empty paragraph
+ * @property {boolean} preserveBlank - Whether or not to keep blank paragraphs when saving editor data
+ */
+interface ParagraphConfig {
+  placeholder: string;
+  preserveBlank: boolean;
+}
+
+/**
+ * @typedef {Object} ParagraphData
+ * @description Tool's input and output data format
+ * @property {String} text — Paragraph's content. Can include HTML tags: <a><b><i>
+ */
+interface ParagraphData {
+  text?: string;
+}
+
+export default class Paragraph {
+  /**
+   * Default placeholder for Paragraph Tool
+   *
+   * @return {string}
+   * @constructor
+   */
+  static get DEFAULT_PLACEHOLDER() {
+    return "";
+  }
+
+  /**
+   * Render plugin`s main Element and fill it with saved data
+   *
+   * @param {object} params - constructor params
+   * @param {ParagraphData} params.data - previously saved data
+   * @param {ParagraphConfig} params.config - user config for Tool
+   * @param {object} params.api - editor.js api
+   * @param {boolean} readOnly - read only mode flag
+   */
+  api: API;
+  readOnly: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _CSS: any;
+  _placeholder: string;
+  _data: ParagraphData;
+  _element: HTMLElement;
+  _preserveBlank: boolean;
+
+  constructor({
+    data,
+    config,
+    api,
+    readOnly,
+  }: {
+    data: ParagraphData;
+    config: ParagraphConfig;
+    api: API;
+    readOnly: boolean;
+  }) {
+    this.api = api;
+    this.readOnly = readOnly;
+
+    this._CSS = {
+      block: this.api.styles.block,
+      wrapper: "ce-paragraph",
+    };
+
+    if (!this.readOnly) {
+      this.onKeyUp = this.onKeyUp.bind(this);
+    }
+
+    /**
+     * Placeholder for paragraph if it is first Block
+     * @type {string}
+     */
+    this._placeholder = config.placeholder
+      ? config.placeholder
+      : Paragraph.DEFAULT_PLACEHOLDER;
+    this._data = {};
+    this._element = this.drawView();
+    this._preserveBlank =
+      config.preserveBlank !== undefined ? config.preserveBlank : false;
+
+    this.data = data;
+  }
+
+  /**
+   * Check if text content is empty and set empty string to inner html.
+   * We need this because some browsers (e.g. Safari) insert <br> into empty contenteditanle elements
+   *
+   * @param {KeyboardEvent} e - key up event
+   */
+  onKeyUp(e: KeyboardEvent) {
+    if (e.code !== "Backspace" && e.code !== "Delete") {
+      return;
+    }
+
+    const { textContent } = this._element;
+
+    if (textContent === "") {
+      this._element.innerHTML = "";
+    }
+  }
+
+  /**
+   * Create Tool's view
+   * @return {HTMLElement}
+   * @private
+   */
+  drawView() {
+    const div = document.createElement("DIV");
+
+    div.classList.add(this._CSS.wrapper, this._CSS.block);
+    div.contentEditable = "false";
+    div.dataset.placeholder = this.api.i18n.t(this._placeholder);
+
+    if (!this.readOnly) {
+      div.contentEditable = "true";
+      div.addEventListener("keyup", this.onKeyUp);
+    }
+
+    return div;
+  }
+
+  fetchDynamicValueWithDataText(dataText: string) {
+    let text = "";
+    try {
+      const dataJson = JSON.parse(dataText);
+      text = this.fetchDynamicValue(
+        dataJson.tableName,
+        dataJson.columnName,
+        dataJson.entryKey
+      );
+    } catch (e) {
+      text = "//Error//";
+    }
+    return text;
+  }
+  fetchDynamicValue(tableName: string, columnName: string, entryKey: string) {
+    return `${tableName} ${columnName} ${entryKey}`;
+  }
+
+  /**
+   * Return Tool's view
+   *
+   * @returns {HTMLDivElement}
+   */
+  render() {
+    const finalElement = this._element;
+    if (this.readOnly) {
+      const startStringOfCommand = "//dynamicValue:";
+      const endStringOfCommand = ":dynamicValue//";
+      while (finalElement.innerHTML.search(startStringOfCommand) > 0) {
+        const text = finalElement.innerHTML;
+        const commandStart = text.search(startStringOfCommand);
+        const textWithoutStart = text.substring(
+          commandStart + startStringOfCommand.length
+        );
+        const commandEnd = textWithoutStart.search(endStringOfCommand);
+        const dataText = textWithoutStart.substring(0, commandEnd);
+        const dynamicValue = this.fetchDynamicValueWithDataText(dataText);
+        finalElement.innerHTML = text.replace(
+          startStringOfCommand + dataText + endStringOfCommand,
+          dynamicValue
+        );
+      }
+      return finalElement;
+    }
+    return this._element;
+  }
+
+  /**
+   * Method that specified how to merge two Text blocks.
+   * Called by Editor.js by backspace at the beginning of the Block
+   * @param {ParagraphData} data
+   * @public
+   */
+  merge(data: ParagraphData) {
+    let newText = "";
+    newText += this.data.text !== undefined ? this.data.text : "";
+    newText += data.text !== undefined ? data.text : "";
+    this.data = {
+      text: newText,
+    };
+  }
+
+  /**
+   * Validate Paragraph block data:
+   * - check for emptiness
+   *
+   * @param {ParagraphData} savedData — data received after saving
+   * @returns {boolean} false if saved data is not correct, otherwise true
+   * @public
+   */
+  validate(savedData: ParagraphData) {
+    if (
+      savedData.text !== undefined &&
+      savedData.text.trim() === "" &&
+      !this._preserveBlank
+    ) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Extract Tool's data from the view
+   * @param {HTMLDivElement} toolsContent - Paragraph tools rendered view
+   * @returns {ParagraphData} - saved data
+   * @public
+   */
+  save(toolsContent: HTMLDivElement) {
+    if (this.readOnly) {
+      return this.data;
+    }
+    return {
+      text: toolsContent.innerHTML,
+    };
+  }
+
+  /**
+   * On paste callback fired from Editor.
+   *
+   * @param {PasteEvent} event - event with pasted data
+   */
+  onPaste(event: HTMLPasteEvent) {
+    const data = {
+      text: event.detail.data.innerHTML,
+    };
+
+    this.data = data;
+  }
+
+  /**
+   * Enable Conversion Toolbar. Paragraph can be converted to/from other tools
+   */
+  static get conversionConfig() {
+    return {
+      export: "text", // to convert Paragraph to other block, use 'text' property of saved data
+      import: "text", // to covert other block's exported string to Paragraph, fill 'text' property of tool data
+    };
+  }
+
+  /**
+   * Sanitizer rules
+   */
+  static get sanitize() {
+    return {
+      text: {
+        br: true,
+      },
+    };
+  }
+
+  /**
+   * Returns true to notify the core that read-only mode is supported
+   *
+   * @return {boolean}
+   */
+  static get isReadOnlySupported() {
+    return true;
+  }
+
+  /**
+   * Get current Tools`s data
+   * @returns {ParagraphData} Current data
+   * @private
+   */
+  get data() {
+    const text = this._element.innerHTML;
+
+    this._data.text = text;
+
+    return this._data;
+  }
+
+  /**
+   * Store data in plugin:
+   * - at the this._data property
+   * - at the HTML
+   *
+   * @param {ParagraphData} data — data to set
+   * @private
+   */
+  set data(data) {
+    this._data = data || {};
+
+    this._element.innerHTML = this._data.text || "";
+  }
+
+  /**
+   * Used by Editor paste handling API.
+   * Provides configuration to handle P tags.
+   *
+   * @returns {{tags: string[]}}
+   */
+  static get pasteConfig() {
+    return {
+      tags: ["P"],
+    };
+  }
+
+  /**
+   * Icon and title for displaying at the Toolbox
+   *
+   * @return {{icon: string, title: string}}
+   */
+  static get toolbox() {
+    return {
+      icon: '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0.2 -0.3 9 11.4" width="12" height="14"><path d="M0 2.77V.92A1 1 0 01.2.28C.35.1.56 0 .83 0h7.66c.28.01.48.1.63.28.14.17.21.38.21.64v1.85c0 .26-.08.48-.23.66-.15.17-.37.26-.66.26-.28 0-.5-.09-.64-.26a1 1 0 01-.21-.66V1.69H5.6v7.58h.5c.25 0 .45.08.6.23.17.16.25.35.25.6s-.08.45-.24.6a.87.87 0 01-.62.22H3.21a.87.87 0 01-.61-.22.78.78 0 01-.24-.6c0-.25.08-.44.24-.6a.85.85 0 01.61-.23h.5V1.7H1.73v1.08c0 .26-.08.48-.23.66-.15.17-.37.26-.66.26-.28 0-.5-.09-.64-.26A1 1 0 010 2.77z"/></svg>',
+      title: "Text",
+    };
+  }
+}

--- a/src/components/Widgets/InlineDynamicValueWiget.tsx
+++ b/src/components/Widgets/InlineDynamicValueWiget.tsx
@@ -1,0 +1,74 @@
+export default class InlineDynamicValueWidget {
+  _state: boolean;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _button: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  _api: any;
+
+  static get isInline() {
+    return true;
+  }
+  get state() {
+    return this._state;
+  }
+
+  set state(state) {
+    this._state = state;
+    this._button.classList.toggle(
+      this._api.styles.inlineToolButtonActive,
+      state
+    );
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  constructor({ api }: any) {
+    this._api = api;
+    this._button = null;
+    this._state = false;
+  }
+
+  render() {
+    this._button = document.createElement("button");
+    this._button.type = "button";
+    this._button.textContent = "V";
+    this._button.classList.add(this._api.styles.inlineToolButton);
+
+    return this._button;
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  surround(range: any) {
+    if (this.state) {
+      this.unwrap(range);
+      return;
+    }
+    this.wrap(range);
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  wrap(range: any) {
+    //const selectedText = range.extractContents();
+    const dynamicValue = "$dynamicValue$"; //getDynamicVauleBy...(selectedText)
+
+    range.insertNode(document.createTextNode(dynamicValue));
+
+    this._api.selection.expandToTag(dynamicValue);
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  unwrap(range: any) {
+    const mark = this._api.selection.findParentTag("MARK");
+
+    mark.remove();
+
+    range.insertNode(document.createTextNode(mark.outerText));
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  checkState(selection: any) {
+    const text = selection.anchorNode;
+
+    if (!text) {
+      return;
+    }
+
+    const anchorElement = text instanceof Element ? text : text.parentElement;
+
+    this.state = !!anchorElement.closest("MARK");
+  }
+}

--- a/src/components/Widgets/InlineDynamicValueWiget.tsx
+++ b/src/components/Widgets/InlineDynamicValueWiget.tsx
@@ -1,74 +1,33 @@
+import { API } from "@editorjs/editorjs";
+import "./DynamicValueWidget.css";
+
 export default class InlineDynamicValueWidget {
-  _state: boolean;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _button: any;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  _api: any;
+  _button: HTMLButtonElement;
+  api: API;
 
   static get isInline() {
     return true;
   }
-  get state() {
-    return this._state;
-  }
 
-  set state(state) {
-    this._state = state;
-    this._button.classList.toggle(
-      this._api.styles.inlineToolButtonActive,
-      state
-    );
-  }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  constructor({ api }: any) {
-    this._api = api;
-    this._button = null;
-    this._state = false;
+  constructor({ api }: { api: API }) {
+    this.api = api;
+    this._button = document.createElement("button");
+    this._button.type = "button";
+    this._button.textContent = "dV";
+    this._button.classList.add(this.api.styles.inlineToolButton);
   }
 
   render() {
-    this._button = document.createElement("button");
-    this._button.type = "button";
-    this._button.textContent = "V";
-    this._button.classList.add(this._api.styles.inlineToolButton);
-
     return this._button;
   }
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   surround(range: any) {
-    if (this.state) {
-      this.unwrap(range);
-      return;
-    }
-    this.wrap(range);
+    range.deleteContents();
+    const text = document.createTextNode(
+      '//dynamicValue:{"tableName":"","columnName":"","entryKey":""}:dynamicValue//'
+    );
+    range.insertNode(text);
   }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  wrap(range: any) {
-    //const selectedText = range.extractContents();
-    const dynamicValue = "$dynamicValue$"; //getDynamicVauleBy...(selectedText)
-
-    range.insertNode(document.createTextNode(dynamicValue));
-
-    this._api.selection.expandToTag(dynamicValue);
-  }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  unwrap(range: any) {
-    const mark = this._api.selection.findParentTag("MARK");
-
-    mark.remove();
-
-    range.insertNode(document.createTextNode(mark.outerText));
-  }
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  checkState(selection: any) {
-    const text = selection.anchorNode;
-
-    if (!text) {
-      return;
-    }
-
-    const anchorElement = text instanceof Element ? text : text.parentElement;
-
-    this.state = !!anchorElement.closest("MARK");
-  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  checkState() {}
 }

--- a/src/components/internal/PageEdit.tsx
+++ b/src/components/internal/PageEdit.tsx
@@ -182,6 +182,7 @@ const PageEdit: React.FC<PageProperties> = ({
           onReady={handleReady}
           onChange={handleSave}
           placeholder="start writing here..."
+          defaultBlock="paragraph"
         />
         {/* <ReactEditorJS tools={EDITOR_JS_TOOLS} /> */}
         <div className="float-right m-5">

--- a/src/components/internal/tools.js
+++ b/src/components/internal/tools.js
@@ -9,6 +9,7 @@ import Alert from "editorjs-alert";
 import Table from "@editorjs/table";
 
 import DynamicValueWidget from "../Widgets/DynamicValueWidget";
+import InlineDynamicValueWidget from "../Widgets/InlineDynamicValueWiget";
 
 export const EDITOR_JS_TOOLS = {
   // NOTE: Paragraph is default tool. Declare only when you want to change paragraph option.
@@ -26,4 +27,5 @@ export const EDITOR_JS_TOOLS = {
   },
   table: { class: Table, inlineToolbar: true, shortcut: "CMD+SHIFT+T" },
   dynamicValue: DynamicValueWidget,
+  dynamicValueInline: InlineDynamicValueWidget,
 };

--- a/src/components/internal/tools.js
+++ b/src/components/internal/tools.js
@@ -7,13 +7,14 @@ import Header from "@editorjs/header";
 import List from "@editorjs/list";
 import Alert from "editorjs-alert";
 import Table from "@editorjs/table";
+import Paragraph from "../Widgets/CustomParagraph";
 
 import DynamicValueWidget from "../Widgets/DynamicValueWidget";
 import InlineDynamicValueWidget from "../Widgets/InlineDynamicValueWiget";
 
 export const EDITOR_JS_TOOLS = {
   // NOTE: Paragraph is default tool. Declare only when you want to change paragraph option.
-  // paragraph: Paragraph,
+  paragraph: { class: Paragraph, inlineToolbar: true },
   header: { class: Header, shortcut: "CMD+SHIFT+H" },
   list: { class: List, shortcut: "CMD+SHIFT+L" },
   alert: {


### PR DESCRIPTION
The Inline Tool will add: `//dynamicValue:{"tableName":"","columnName":"","entryKey":""}:dynamicValue//` for the selected range.

The custom Paragraph is based on the paragraph tool of editor js and only uses a different render function. For readOnly mode the renderFunction will search for `//dynamicValue:.....:dynamicValue//` parts in the string. If found the inside will be parsed into a json and a function can be called